### PR TITLE
Fix build when CFLAGS, etc. are unset

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -41,10 +41,10 @@ env = Environment(
       'RunTests': run_tests_builder,
     })
 
-env.Append(CPPFLAGS = os.environ['CPPFLAGS'],
-           CFLAGS = os.environ['CFLAGS'],
-           CXXFLAGS = os.environ['CXXFLAGS'],
-           LDFLAGS = os.environ['LDFLAGS'])
+env.Append(CPPFLAGS = os.environ.get('CPPFLAGS', ''),
+           CFLAGS = os.environ.get('CFLAGS', ''),
+           CXXFLAGS = os.environ.get('CXXFLAGS', ''),
+           LDFLAGS = os.environ.get('LDFLAGS', ''))
 
 env.Append(CCFLAGS = '-Wall -Werror')
 


### PR DESCRIPTION
This is a small change to the SConstruct file to avoid `KeyError` exceptions when scons is run in an environment where `CFLAGS` and friends have no entries at all in the environment.
