### PR TITLE
Use int value provided by fgetc() to compare against EOF. Casting to char and back to int won't work on specific architectures.

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -197,15 +197,19 @@ bool ConfigParser::FileCharStream::InitImpl(string* error_out) {
 
 bool ConfigParser::FileCharStream::AtEOFImpl() {
   assert(file_);
-  int ch = GetChar();
+  int ch = GetCharPriv();
   UngetChar(ch);
   return ch == EOF;
 }
 
 char ConfigParser::FileCharStream::GetCharImpl() {
-  assert(file_);
-  int ch = fgetc(file_);
+  char ch = GetCharPriv();
   return ch;
+}
+
+int ConfigParser::FileCharStream::GetCharPriv() {
+  assert(file_);
+  return fgetc(file_);
 }
 
 ConfigParser::StringCharStream::StringCharStream(const string& data)
@@ -218,7 +222,13 @@ bool ConfigParser::StringCharStream::AtEOFImpl() {
 }
 
 char ConfigParser::StringCharStream::GetCharImpl() {
-  return data_.at(pos_++);
+  char ret = GetCharPriv();
+  return ret;
+}
+
+int ConfigParser::StringCharStream::GetCharPriv() {
+  int ret = data_.at(pos_++);
+  return ret;
 }
 
 bool ConfigParser::ReadSettingName(string* name_out) {

--- a/config_parser.h
+++ b/config_parser.h
@@ -80,6 +80,7 @@ class ConfigParser {
     virtual bool InitImpl(std::string* error_out) { return true; }
     virtual bool AtEOFImpl() = 0;
     virtual char GetCharImpl() = 0;
+    virtual int  GetCharPriv() = 0;
 
     // Has Init() been called?
     bool initialized_;
@@ -111,6 +112,7 @@ class ConfigParser {
     bool InitImpl(std::string* error_out);
     bool AtEOFImpl();
     char GetCharImpl();
+    int  GetCharPriv();
 
     std::string filename_;
     FILE* file_;
@@ -126,6 +128,7 @@ class ConfigParser {
    private:
     bool AtEOFImpl();
     char GetCharImpl();
+    int  GetCharPriv();
 
     std::string data_;
     size_t pos_;


### PR DESCRIPTION
Example on ppc64 for the old code:
fgetc() reads 0xFFFFFFFF (int, -1). Then converted to 0xFF (char, ÿ).
Then converted to 0x000000FF (int, ÿ).
Compared against EOF macro 0xFFFFFFFF (int, -1).
Obviously not the same value.
