### PR TITLE
Don't cast fgetc()'s return value to a char.

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -70,7 +70,7 @@ bool ConfigParser::Parse(SettingsMap* settings,
   bool in_comment = false;
 
   while (!stream_->AtEOF()) {
-    char ch = stream_->GetChar();
+    int ch = stream_->GetChar();
 
     if (ch == '#') {
       in_comment = true;
@@ -138,7 +138,7 @@ bool ConfigParser::CharStream::AtEOF() {
   return (!have_buffered_char_ && AtEOFImpl());
 }
 
-char ConfigParser::CharStream::GetChar() {
+int ConfigParser::CharStream::GetChar() {
   assert(initialized_);
 
   prev_at_line_end_ = at_line_end_;
@@ -147,7 +147,7 @@ char ConfigParser::CharStream::GetChar() {
     at_line_end_ = false;
   }
 
-  char ch = 0;
+  int ch = 0;
   if (have_buffered_char_) {
     have_buffered_char_ = false;
     ch = buffered_char_;
@@ -161,7 +161,7 @@ char ConfigParser::CharStream::GetChar() {
   return ch;
 }
 
-void ConfigParser::CharStream::UngetChar(char ch) {
+void ConfigParser::CharStream::UngetChar(int ch) {
   if (prev_at_line_end_)
     line_num_--;
   at_line_end_ = prev_at_line_end_;
@@ -202,10 +202,9 @@ bool ConfigParser::FileCharStream::AtEOFImpl() {
   return ch == EOF;
 }
 
-char ConfigParser::FileCharStream::GetCharImpl() {
+int ConfigParser::FileCharStream::GetCharImpl() {
   assert(file_);
-  int ch = fgetc(file_);
-  return ch;
+  return fgetc(file_);
 }
 
 ConfigParser::StringCharStream::StringCharStream(const string& data)
@@ -217,7 +216,7 @@ bool ConfigParser::StringCharStream::AtEOFImpl() {
   return pos_ == data_.size();
 }
 
-char ConfigParser::StringCharStream::GetCharImpl() {
+int ConfigParser::StringCharStream::GetCharImpl() {
   return data_.at(pos_++);
 }
 
@@ -230,7 +229,7 @@ bool ConfigParser::ReadSettingName(string* name_out) {
     if (stream_->AtEOF())
       break;
 
-    char ch = stream_->GetChar();
+    int ch = stream_->GetChar();
     if (isspace(ch) || ch == '#') {
       stream_->UngetChar(ch);
       break;
@@ -287,7 +286,7 @@ bool ConfigParser::ReadValue(Setting** setting_ptr) {
     return false;
   }
 
-  char ch = stream_->GetChar();
+  int ch = stream_->GetChar();
   stream_->UngetChar(ch);
 
   if ((ch >= '0' && ch <= '9') || ch == '-') {
@@ -322,7 +321,7 @@ bool ConfigParser::ReadInteger(int32_t* int_out) {
     if (stream_->AtEOF())
       break;
 
-    char ch = stream_->GetChar();
+    int ch = stream_->GetChar();
     if (isspace(ch) || ch == '#') {
       stream_->UngetChar(ch);
       break;
@@ -383,7 +382,7 @@ bool ConfigParser::ReadString(string* str_out) {
       return false;
     }
 
-    char ch = stream_->GetChar();
+    int ch = stream_->GetChar();
     if (ch == '\n') {
       SetErrorF("Got newline mid-string");
       return false;
@@ -440,7 +439,7 @@ bool ConfigParser::ReadColor(uint16_t* red_out,
       return false;
     }
 
-    char ch = stream_->GetChar();
+    int ch = stream_->GetChar();
     if (ch == '\n') {
       SetErrorF("Got newline mid-color");
       return false;

--- a/config_parser.h
+++ b/config_parser.h
@@ -70,16 +70,16 @@ class ConfigParser {
     bool AtEOF();
 
     // Get the next character in the stream.
-    char GetChar();
+    int GetChar();
 
     // Push a previously-read character back onto the stream.
     // At most one character can be buffered.
-    void UngetChar(char ch);
+    void UngetChar(int ch);
 
    private:
     virtual bool InitImpl(std::string* error_out) { return true; }
     virtual bool AtEOFImpl() = 0;
-    virtual char GetCharImpl() = 0;
+    virtual int GetCharImpl() = 0;
 
     // Has Init() been called?
     bool initialized_;
@@ -88,7 +88,7 @@ class ConfigParser {
     bool have_buffered_char_;
 
     // The character returned by UngetChar().
-    char buffered_char_;
+    int buffered_char_;
 
     // Are we currently at the end of the line?
     bool at_line_end_;
@@ -110,7 +110,7 @@ class ConfigParser {
    private:
     bool InitImpl(std::string* error_out);
     bool AtEOFImpl();
-    char GetCharImpl();
+    int GetCharImpl();
 
     std::string filename_;
     FILE* file_;
@@ -125,7 +125,7 @@ class ConfigParser {
 
    private:
     bool AtEOFImpl();
-    char GetCharImpl();
+    int GetCharImpl();
 
     std::string data_;
     size_t pos_;


### PR DESCRIPTION
Fix an issue described by Mihai Moldovan: int values
returned by ConfigParser::FileCharStream::GetCharImpl() were
cast to chars, resulting in EOF getting lost.
