### PR TITLE
Merge changes from Debian: LDFLAGS → LINKFLAGS + Google Code → GitHub in man pages

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -44,7 +44,7 @@ env = Environment(
 env.Append(CPPFLAGS=os.environ.get('CPPFLAGS', ''),
            CFLAGS=os.environ.get('CFLAGS', ''),
            CXXFLAGS=os.environ.get('CXXFLAGS', ''),
-           LDFLAGS=os.environ.get('LDFLAGS', ''))
+           LINKFLAGS=os.environ.get('LDFLAGS', ''))
 
 env.Append(CCFLAGS='-Wall -Werror -Wno-narrowing')
 

--- a/dump_xsettings.1
+++ b/dump_xsettings.1
@@ -17,7 +17,7 @@ Display a help message and exit.
 \fB\-s\fR, \fB\-\-screen\fR=\fISCREEN\fR
 Use the X screen numbered \fISCREEN\fR (default is 0).
 .SH BUGS
-\fIhttp://code.google.com/p/xsettingsd/issues/list\fR
+\fIhttps://github.com/derat/xsettingsd/issues\fR
 .SH SEE ALSO
 \fIxsettingsd\fR(1)
 .SH AUTHOR

--- a/xsettingsd.1
+++ b/xsettingsd.1
@@ -15,7 +15,7 @@ GTK+ applications and want to configure things such as themes, font
 antialiasing/hinting, and UI sound effects.
 .PP
 Additional documentation is available at the project's website:
-\fIhttp://code.google.com/p/xsettingsd/\fR
+\fIhttps://github.com/derat/xsettingsd\fR
 .SH OPTIONS
 .TP
 \fB\-c\fR, \fB\-\-config\fR=\fIFILE\fR
@@ -27,7 +27,7 @@ Display a help message and exit.
 \fB\-s\fR, \fB\-\-screen\fR=\fISCREEN\fR
 Use the X screen numbered \fISCREEN\fR (default of -1 means all screens).
 .SH BUGS
-\fIhttp://code.google.com/p/xsettingsd/issues/list\fR
+\fIhttps://github.com/derat/xsettingsd/issues\fR
 .SH EXAMPLE
 Running \fIdump_xsettings\fR(1) while another XSETTINGS daemon, such as
 \fBgnome-settings-daemon\fR, is already running will print your current


### PR DESCRIPTION
These two patches are [applied to the Debian package of xsettingsd](https://anonscm.debian.org/cgit/collab-maint/xsettingsd.git/tree/debian/patches).

The s/LDFLAGS/LINKFLAGS/ patch is already applied for quite a while to make linker flags being passed through properly as Debian requires this to be able to pass through hardening build flags.

The second one is just from today after I noticed that the the home page URL just has been updated in the README, but not in the man pages.