### PR TITLE
Return 1 to indicate error from main()

### DIFF
--- a/dump_xsettings.cc
+++ b/dump_xsettings.cc
@@ -270,7 +270,7 @@ int main(int argc, char** argv) {
 
   xsettingsd::DataReader reader(buffer, data_size);
   if (!xsettingsd::DumpSettings(&reader))
-    return false;
+    return 1;
 
   return 0;
 }


### PR DESCRIPTION
The statement 'return false;' was most likely to end up indicating successful exit 
by returning a 0 value, when failure seems to be intended.

This was flagged as a warning in the Debian Clang Archive Rebuild.