### PR TITLE
use FindX11's detected include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(GNUInstallDirs)
 include(CTest)
 
 find_package(X11 REQUIRED)
+include_directories(${X11_INCLUDE_DIR})
 find_package(GTest)
 
 add_library(libxsettingsd STATIC


### PR DESCRIPTION
The X11 include path isn't always in the compiler's default search path; use the value detected by CMake's FindX11 module to set this.